### PR TITLE
API-change & removed gaussian blur

### DIFF
--- a/lektor_thumbnail_generator.py
+++ b/lektor_thumbnail_generator.py
@@ -103,9 +103,7 @@ class ResizedImageBuildProgram(AttachmentBuildProgram):
                             extra_params=[
                                 "-strip",
                                 "-interlace",
-                                "Plane",
-                                "-gaussian-blur",
-                                "0.05",
+                                "Plane"
                             ],
                         )
 

--- a/lektor_thumbnail_generator.py
+++ b/lektor_thumbnail_generator.py
@@ -103,7 +103,7 @@ class ResizedImageBuildProgram(AttachmentBuildProgram):
                             extra_params=[
                                 "-strip",
                                 "-interlace",
-                                "Plane"
+                                "Plane",
                             ],
                         )
 

--- a/lektor_thumbnail_generator.py
+++ b/lektor_thumbnail_generator.py
@@ -4,7 +4,7 @@ import shutil
 from lektor.build_programs import AttachmentBuildProgram, buildprogram
 from lektor.context import get_ctx
 from lektor.db import Image
-from lektor.imagetools import (computed_height, find_imagemagick,
+from lektor.imagetools import (compute_dimensions, find_imagemagick,
                                get_image_info, get_quality)
 from lektor.pluginsystem import Plugin
 from lektor.reporter import reporter
@@ -78,7 +78,7 @@ class ResizedImageBuildProgram(AttachmentBuildProgram):
             height = int(conf.get("max_height", "0"))
 
             if not height:
-                height = computed_height(source_img, width, w, h)
+                _, height = compute_dimensions(width, None, w, h)
 
             df = artifact.source_obj.url_path
             ext_pos = df.rfind(".")


### PR DESCRIPTION
Hi there, first of all: thank you for this great plugin, I have been using it for years, it is exactly what I was (and still am) looking for.

I noticed your last commit (e08fdd1e8aa17dfa54a69c5f3fd4e09152169d64) you have reverted a previous changed made through a pull request, I assume this was in error. That change was in response to API-changes in lektor which now appear to have progressed further, completely dropping the source image as an argument from the "compute_dimensions" function.

You also added Gaussian blur, which has noticeable effects on thumbnails/images which have font in them, I would suggest removing that (as I have done in one of these two commits) or making it optional. Adding a generic section to the config-ini seems to contrast starkly with the otherwise very simple structure of it, which didn't seem appropriate to me. So I have opted for the removal choice.

Maybe a minor version-bump would be appropriate to signify the change in compatibility with the lektor 3.2.0 API.

If you need any changes, let me know.